### PR TITLE
Explicitly require ApplicationController

### DIFF
--- a/app/controllers/pg_bouncer_hero/database_controller.rb
+++ b/app/controllers/pg_bouncer_hero/database_controller.rb
@@ -1,3 +1,5 @@
+require_dependency 'pg_bouncer_hero/application_controller'
+
 module PgBouncerHero
   class DatabaseController < ApplicationController
     def summary

--- a/app/controllers/pg_bouncer_hero/home_controller.rb
+++ b/app/controllers/pg_bouncer_hero/home_controller.rb
@@ -1,3 +1,5 @@
+require_dependency 'pg_bouncer_hero/application_controller'
+
 module PgBouncerHero
   class HomeController < ApplicationController
     def index


### PR DESCRIPTION
Without the explicit require statement it is possible that the
controller will inherit from the wrong ApplicationController. This can
happen in development when a different ApplicationController has already
been loaded and Rails then doesn't run into const_missing anymore when
trying to load ApplicationController.